### PR TITLE
Test clangd's support for multiple compilation databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+multi-project/build
+.clangd-index

--- a/ls_interact.py
+++ b/ls_interact.py
@@ -151,6 +151,26 @@ class GotoDefinition(Base):
         return obj
 
 
+class FindReferences(Base):
+
+    def __init__(self, path, line, col):
+        super().__init__('textDocument/references')
+        self._path = path
+        self._line = line
+        self._col = col
+
+    def get_params(self):
+        obj = {}
+
+        obj['textDocument'] = {}
+        obj['textDocument']['uri'] = 'file://' + self._path
+        obj['position'] = {}
+        obj['position']['line'] = self._line - 1
+        obj['position']['character'] = self._col - 1
+
+        return obj
+
+
 class CodeLens(Base):
 
     def __init__(self, path):
@@ -242,7 +262,7 @@ class WorkspaceSymbol(Base):
         }
 
 
-def run(callback, initialize_params={}):
+def run(callback, cmdline_args="", initialize_params={}):
     argparser = argparse.ArgumentParser()
     argparser.add_argument('server',
                            help=('server executable (may contain additional ' +
@@ -260,7 +280,7 @@ def run(callback, initialize_params={}):
         json_rpc = common.JsonRpc(sock, sock, args.log,
                                   args.log_pretty)
     else:
-        server = common.start_tool(args.server)
+        server = common.start_tool('{} {}'.format(args.server, cmdline_args))
         json_rpc = common.JsonRpc(server.stdin, server.stdout, args.log,
                                   args.log_pretty)
 

--- a/multi-project/README.md
+++ b/multi-project/README.md
@@ -1,0 +1,5 @@
+To build, run `setup.sh`.
+
+This repo contains two separate projects, a library `libfoo` and an application
+`bar`, which uses `libfoo`.  They are built independently in out-of-tree build
+directories.

--- a/multi-project/setup.sh
+++ b/multi-project/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+mkdir -p build/libfoo
+mkdir -p build/bar
+
+pushd build/libfoo
+  cmake ../../source/libfoo -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DCMAKE_BUILD_TYPE=Debug
+  make
+popd
+
+pushd build/bar
+  cmake ../../source/bar -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DCMAKE_BUILD_TYPE=Debug
+  make
+popd

--- a/multi-project/source/bar/CMakeLists.txt
+++ b/multi-project/source/bar/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+project (bar)
+add_executable(bar bar.cpp)
+target_include_directories(bar PRIVATE ../libfoo)
+target_link_libraries(bar ${CMAKE_BINARY_DIR}/../libfoo/libfoo.a)

--- a/multi-project/source/bar/bar.cpp
+++ b/multi-project/source/bar/bar.cpp
@@ -1,0 +1,9 @@
+#include <foo.h>
+#include <iostream>
+
+int main() {
+  int a = 6, b = 9;
+  int result = Multiply(a, b);
+  std::cout << "The result is " << result << std::endl;
+  return 0;
+}

--- a/multi-project/source/libfoo/CMakeLists.txt
+++ b/multi-project/source/libfoo/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.5)
+project (libfoo)
+add_library(foo foo.cpp)

--- a/multi-project/source/libfoo/foo.cpp
+++ b/multi-project/source/libfoo/foo.cpp
@@ -1,0 +1,3 @@
+int Multiply(int a, int b) {
+  return a * b;
+}

--- a/multi-project/source/libfoo/foo.h
+++ b/multi-project/source/libfoo/foo.h
@@ -1,0 +1,1 @@
+int Multiply(int a, int b);

--- a/test_clangd_multi_project.py
+++ b/test_clangd_multi_project.py
@@ -1,0 +1,65 @@
+#
+# Run with: python3 test_clangd.py --log --log-pretty "/path/to/clangd --compile-commands-dir ${PWD}/cpp-test/build-1"
+#
+
+import ls_interact as ls
+from common import JsonRpc
+import os
+
+root = os.getcwd() + '/multi-project/'
+
+def interact(json_rpc):
+
+    paths = [root + 'source/bar/bar.cpp',
+             root + 'source/libfoo/foo.cpp']
+
+    for p in paths:
+        json_rpc.notify(ls.DidOpenTextDocument(p))
+
+    for p in paths:
+        json_rpc.wait_for(JsonRpc.JsonRpcPendingMethod(
+            'textDocument/publishDiagnostics'))
+
+    # ctrl-click on Multiply() in bar.cpp
+    r = json_rpc.request(ls.GotoDefinition(paths[0], 6, 21))
+    r = json_rpc.wait_for(r)
+    # check that the definition in foo.cpp is found
+    assert len(r) >= 1
+    assert r[0]['uri'].endswith('/foo.cpp')
+
+    # find references to Multiple() in foo.cpp
+    r = json_rpc.request(ls.FindReferences(paths[1], 1, 6))
+    r = json_rpc.wait_for(r)
+    # check that the call site in bar.cpp is found
+    found = False
+    for ref in r:
+        if ref['uri'].endswith('/bar.cpp'):
+            found = True
+            break
+    assert found
+
+
+def main():
+    ret = os.system('cd multi-project && ./setup.sh')
+    if ret != 0:
+        return ret
+
+    ls.run(interact, cmdline_args='--background-index', initialize_params={
+        'rootUri': 'file://' + root + 'source',
+        'initializationOptions': {
+            'compilationDatabaseMap': [
+                {
+                    'sourceDir': root + 'source/libfoo',
+                    'dbPath': root + 'build/libfoo'
+                },
+                {
+                    'sourceDir': root + 'source/bar',
+                    'dbPath': root + 'build/bar'
+                }
+            ]
+        }
+    })
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
* Add multi-project example codebase from https://github.com/simark/clangd-multi-project-test
* Add support for `FindReferences` request
* Add testcase to exercise multi-project support in clangd
* Corresponding server-side change is at https://github.com/HighCommander4/llvm-project/tree/multi-project